### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+<!-- Briefly describe the changes and the purpose of the PR. -->
+
+## Related Issue
+<!-- Mention the related issue number if applicable. -->
+
+## Changes
+<!-- List the main changes made in this PR. -->
+
+## Testing
+<!-- Briefly describe the testing steps or results. -->
+
+## Other Information
+<!-- Add any other relevant information for the reviewer. -->


### PR DESCRIPTION
This is a Org-wide pull request template.
If you create `.github/pull_request_template.md` in route06inc repository, the repository template will take precedence.